### PR TITLE
Wrong catkin macro invocation

### DIFF
--- a/agvs_control/CMakeLists.txt
+++ b/agvs_control/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(agvs_control)
 
+find_package(catkin REQUIRED)
 catkin_package()
-


### PR DESCRIPTION
Moved from https://github.com/RobotnikAutomation/agvs/pull/1

Without this PR, `catkin_make` passes w/o error for me. But a new tool [catkin_tools](https://github.com/catkin/catkin_tools/) (maybe next version of catkin_make? Not sure but it works way faster so I like it) fails, which I'm not sure what catkin_tools is supposed to or not. Anyway, no need to leave empty `catkin_package` macro I think.
